### PR TITLE
Fix green coffee stock mismatch and retail order quantity calculations

### DIFF
--- a/src/lib/haircut-service.js
+++ b/src/lib/haircut-service.js
@@ -1,4 +1,9 @@
 import { PrismaClient } from '@prisma/client';
+import {
+  calculateAvailableRetailKg,
+  calculateGreenConsumption,
+  calculateHaircutAmount as calculateHaircutAmountFromRetail,
+} from '@/lib/retail-quantity';
 
 // Default haircut percentage (15%)
 const DEFAULT_HAIRCUT_PERCENTAGE = 15;
@@ -98,12 +103,10 @@ export async function updateHaircutPercentage(percentage, userId, prisma) {
 export async function calculateGreenCoffeeConsumption(retailQuantity, prisma) {
   try {
     const haircutPercentage = await getHaircutPercentage(prisma);
-    const haircutMultiplier = 1 + (haircutPercentage / 100);
-    return retailQuantity * haircutMultiplier;
+    return calculateGreenConsumption(retailQuantity, haircutPercentage);
   } catch (error) {
     console.error('Error calculating green coffee consumption:', error);
-    // Fallback to default haircut
-    return retailQuantity * (1 + (DEFAULT_HAIRCUT_PERCENTAGE / 100));
+    return calculateGreenConsumption(retailQuantity, DEFAULT_HAIRCUT_PERCENTAGE);
   }
 }
 
@@ -116,11 +119,10 @@ export async function calculateGreenCoffeeConsumption(retailQuantity, prisma) {
 export async function calculateHaircutAmount(retailQuantity, prisma) {
   try {
     const haircutPercentage = await getHaircutPercentage(prisma);
-    return retailQuantity * (haircutPercentage / 100);
+    return calculateHaircutAmountFromRetail(retailQuantity, haircutPercentage);
   } catch (error) {
     console.error('Error calculating haircut amount:', error);
-    // Fallback to default haircut
-    return retailQuantity * (DEFAULT_HAIRCUT_PERCENTAGE / 100);
+    return calculateHaircutAmountFromRetail(retailQuantity, DEFAULT_HAIRCUT_PERCENTAGE);
   }
 }
 
@@ -132,22 +134,23 @@ export async function calculateHaircutAmount(retailQuantity, prisma) {
 export async function getHaircutInfo(prisma) {
   try {
     const percentage = await getHaircutPercentage(prisma);
-    const multiplier = 1 + (percentage / 100);
-    
+    const availableFrom100kg = calculateAvailableRetailKg(100, percentage);
+    const greenFor10kgRetail = calculateGreenConsumption(10, percentage);
+    const greenFor25kgRetail = calculateGreenConsumption(25, percentage);
+
     return {
       percentage,
-      multiplier,
-      description: `When retail coffee is ordered, green coffee stock is decreased by ${percentage}% more than the retail quantity to account for processing losses.`,
+      description: `A ${percentage}% processing loss means ${availableFrom100kg.toFixed(1)} kg of retail coffee is available from 100 kg of green stock.`,
       examples: [
         {
           retailOrdered: '10 kg',
-          haircutAmount: `${(10 * percentage / 100).toFixed(1)} kg`,
-          totalGreenConsumption: `${(10 * multiplier).toFixed(1)} kg`
+          haircutAmount: `${calculateHaircutAmountFromRetail(10, percentage).toFixed(1)} kg`,
+          totalGreenConsumption: `${greenFor10kgRetail.toFixed(1)} kg`
         },
         {
           retailOrdered: '25 kg',
-          haircutAmount: `${(25 * percentage / 100).toFixed(1)} kg`,
-          totalGreenConsumption: `${(25 * multiplier).toFixed(1)} kg`
+          haircutAmount: `${calculateHaircutAmountFromRetail(25, percentage).toFixed(1)} kg`,
+          totalGreenConsumption: `${greenFor25kgRetail.toFixed(1)} kg`
         }
       ]
     };
@@ -155,7 +158,6 @@ export async function getHaircutInfo(prisma) {
     console.error('Error getting haircut info:', error);
     return {
       percentage: DEFAULT_HAIRCUT_PERCENTAGE,
-      multiplier: 1 + (DEFAULT_HAIRCUT_PERCENTAGE / 100),
       description: `Default haircut of ${DEFAULT_HAIRCUT_PERCENTAGE}% applied to processing losses.`,
       examples: []
     };

--- a/src/lib/retail-quantity.js
+++ b/src/lib/retail-quantity.js
@@ -1,0 +1,126 @@
+export const BAG_WEIGHTS = {
+  SMALL: 0.2,
+  MEDIUM: 0.5,
+  LARGE: 1.0,
+};
+
+/**
+ * Convert bag counts to retail kilograms.
+ */
+export function calculateRetailKgFromBags({
+  smallBagsEspresso = 0,
+  smallBagsFilter = 0,
+  mediumBagsEspresso = 0,
+  mediumBagsFilter = 0,
+  largeBags = 0,
+} = {}) {
+  const smallEspresso = Number(smallBagsEspresso) || 0;
+  const smallFilter = Number(smallBagsFilter) || 0;
+  const mediumEspresso = Number(mediumBagsEspresso) || 0;
+  const mediumFilter = Number(mediumBagsFilter) || 0;
+  const large = Number(largeBags) || 0;
+
+  return (
+    (smallEspresso + smallFilter) * BAG_WEIGHTS.SMALL +
+    (mediumEspresso + mediumFilter) * BAG_WEIGHTS.MEDIUM +
+    large * BAG_WEIGHTS.LARGE
+  );
+}
+
+/**
+ * Retail kg available to order from current green stock after processing loss.
+ * Example: 100kg green with 15% loss => 85kg retail available.
+ */
+export function calculateAvailableRetailKg(greenStockKg, haircutPercentage) {
+  const greenStock = Number(greenStockKg) || 0;
+  if (greenStock <= 0) return 0;
+
+  const pct = clampHaircutPercentage(haircutPercentage);
+  return roundKg(greenStock * (1 - pct / 100));
+}
+
+/**
+ * Green coffee consumed when fulfilling a retail order.
+ * Example: 85kg retail with 15% loss => 100kg green consumed.
+ */
+export function calculateGreenConsumption(retailKg, haircutPercentage) {
+  const retail = Number(retailKg) || 0;
+  if (retail <= 0) return 0;
+
+  const pct = clampHaircutPercentage(haircutPercentage);
+  if (pct >= 100) return retail;
+
+  return roundKg(retail / (1 - pct / 100));
+}
+
+/**
+ * Processing loss amount in kg for a retail order.
+ */
+export function calculateHaircutAmount(retailKg, haircutPercentage) {
+  const retail = Number(retailKg) || 0;
+  if (retail <= 0) return 0;
+
+  return roundKg(calculateGreenConsumption(retail, haircutPercentage) - retail);
+}
+
+/**
+ * Shop inventory kg from bag counts (informational only).
+ */
+export function calculateShopInventoryKg({
+  smallBags = 0,
+  smallBagsEspresso = 0,
+  smallBagsFilter = 0,
+  mediumBagsEspresso = 0,
+  mediumBagsFilter = 0,
+  largeBags = 0,
+} = {}) {
+  const legacySmall = Number(smallBags) || 0;
+  const espresso = Number(smallBagsEspresso) || 0;
+  const filter = Number(smallBagsFilter) || 0;
+  const mediumEspresso = Number(mediumBagsEspresso) || 0;
+  const mediumFilter = Number(mediumBagsFilter) || 0;
+  const large = Number(largeBags) || 0;
+
+  const smallTotal =
+    espresso + filter + (legacySmall > 0 && espresso === 0 && filter === 0 ? legacySmall : 0);
+
+  return roundKg(
+    smallTotal * BAG_WEIGHTS.SMALL +
+      (mediumEspresso + mediumFilter) * BAG_WEIGHTS.MEDIUM +
+      large * BAG_WEIGHTS.LARGE
+  );
+}
+
+/**
+ * Count total bags for label tracking without double-counting legacy fields.
+ */
+export function countTotalBags(item = {}) {
+  const smallBags = Number(item.smallBags) || 0;
+  const smallBagsEspresso = Number(item.smallBagsEspresso) || 0;
+  const smallBagsFilter = Number(item.smallBagsFilter) || 0;
+  const mediumBagsEspresso = Number(item.mediumBagsEspresso) || 0;
+  const mediumBagsFilter = Number(item.mediumBagsFilter) || 0;
+  const largeBags = Number(item.largeBags) || 0;
+
+  const legacySmall =
+    smallBags > 0 && smallBagsEspresso === 0 && smallBagsFilter === 0 ? smallBags : 0;
+
+  return (
+    smallBagsEspresso +
+    smallBagsFilter +
+    legacySmall +
+    mediumBagsEspresso +
+    mediumBagsFilter +
+    largeBags
+  );
+}
+
+function clampHaircutPercentage(haircutPercentage) {
+  const pct = Number(haircutPercentage);
+  if (Number.isNaN(pct)) return 15;
+  return Math.min(100, Math.max(0, pct));
+}
+
+function roundKg(value) {
+  return parseFloat(Number(value).toFixed(4));
+}

--- a/src/pages/api/retail/available-coffee.js
+++ b/src/pages/api/retail/available-coffee.js
@@ -2,6 +2,11 @@
 import { PrismaClient } from '@prisma/client';
 import { getServerSession } from '@/lib/session';
 import { getHaircutPercentage } from '@/lib/haircut-service';
+import {
+  calculateAvailableRetailKg,
+  calculateHaircutAmount,
+  calculateShopInventoryKg,
+} from '@/lib/retail-quantity';
 
 export default async function handler(req, res) {
   // Create a dedicated prisma instance for this request
@@ -177,7 +182,7 @@ export default async function handler(req, res) {
       // Additional validation: filter out any coffees that somehow have zero stock in both places
       const filteredCoffee = coffee.filter(item => {
         if (item.source === 'shop_inventory') {
-          const hasStock = (item.shopSmallBags > 0 || item.shopSmallBagsEspresso > 0 || item.shopSmallBagsFilter > 0 || item.largeBags > 0);
+          const hasStock = (item.shopSmallBags > 0 || item.shopSmallBagsEspresso > 0 || item.shopSmallBagsFilter > 0 || item.shopLargeBags > 0);
           if (!hasStock) {
             console.log(`Filtering out shop inventory coffee with zero stock: ${item.name}`);
           }
@@ -206,7 +211,7 @@ export default async function handler(req, res) {
       const finalFilteredCoffee = filteredCoffee.filter(item => {
         let hasStock = false;
         if (item.source === 'shop_inventory') {
-          hasStock = (item.shopSmallBags > 0 || item.shopSmallBagsEspresso > 0 || item.shopSmallBagsFilter > 0 || item.largeBags > 0);
+          hasStock = (item.shopSmallBags > 0 || item.shopSmallBagsEspresso > 0 || item.shopSmallBagsFilter > 0 || item.shopLargeBags > 0);
         } else if (item.source === 'green_stock') {
           hasStock = item.originalQuantity > 0;
         } else if (item.source === 'both') {
@@ -215,7 +220,7 @@ export default async function handler(req, res) {
         
         if (!hasStock) {
           console.log(`FINAL FILTER: Removing coffee with zero stock: ${item.name} (${item.source})`);
-          console.log(`  Shop stock: Small=${item.shopSmallBags || 0}, Small Espresso=${item.shopSmallBagsEspresso || 0}, Small Filter=${item.shopSmallBagsFilter || 0}, Large=${item.largeBags || 0}`);
+          console.log(`  Shop stock: Small=${item.shopSmallBags || 0}, Small Espresso=${item.shopSmallBagsEspresso || 0}, Small Filter=${item.shopSmallBagsFilter || 0}, Large=${item.shopLargeBags || 0}`);
           console.log(`  Green stock: ${item.originalQuantity}`);
         }
         
@@ -246,25 +251,23 @@ export default async function handler(req, res) {
     
     const coffeeWithHaircut = coffee.map(item => {
       if (item.source === 'green_stock' && item.originalQuantity > 0) {
-        // For green stock coffees, show the quantity AFTER haircut (this is what's actually available for ordering)
-        const haircutAmount = parseFloat((item.originalQuantity * (haircutPercentage / 100)).toFixed(2));
-        const quantityAfterHaircut = parseFloat((item.originalQuantity * (1 - haircutPercentage / 100)).toFixed(2));
+        const quantityAfterHaircut = calculateAvailableRetailKg(item.originalQuantity, haircutPercentage);
+        const haircutAmount = calculateHaircutAmount(quantityAfterHaircut, haircutPercentage);
         
         console.log(`[available-coffee] ${item.name}: Green stock ${item.originalQuantity}kg, haircut ${haircutAmount}kg (${haircutPercentage}%), available for ordering: ${quantityAfterHaircut}kg`);
         
         return {
           ...item,
-          quantity: quantityAfterHaircut, // Show quantity AFTER haircut (what's actually available for ordering)
+          quantity: quantityAfterHaircut,
           haircutAmount: haircutAmount,
           haircutPercentage: haircutPercentage,
-          originalQuantity: item.originalQuantity, // Keep original for reference
+          originalQuantity: item.originalQuantity,
           note: `Green stock: ${item.originalQuantity}kg. After ${haircutPercentage}% haircut: ${quantityAfterHaircut}kg available for ordering.`
         };
       } else if (item.source === 'both' && item.originalQuantity > 0) {
-        // This coffee has both shop inventory AND green stock - show green stock for ordering
-        const haircutAmount = parseFloat((item.originalQuantity * (haircutPercentage / 100)).toFixed(2));
-        const quantityAfterHaircut = parseFloat((item.originalQuantity * (1 - haircutPercentage / 100)).toFixed(2));
-        const shopTotalQuantity = (item.shopSmallBags * 0.2) + (item.shopSmallBagsEspresso * 0.2) + (item.shopSmallBagsFilter * 0.2) + (item.shopLargeBags * 1.0);
+        const quantityAfterHaircut = calculateAvailableRetailKg(item.originalQuantity, haircutPercentage);
+        const haircutAmount = calculateHaircutAmount(quantityAfterHaircut, haircutPercentage);
+        const shopTotalQuantity = calculateShopInventoryKg(item);
         
         console.log(`[available-coffee] ${item.name}: Both sources - Shop inventory: ${shopTotalQuantity.toFixed(2)}kg, Green stock: ${item.originalQuantity}kg, available for ordering: ${quantityAfterHaircut}kg`);
         
@@ -278,16 +281,13 @@ export default async function handler(req, res) {
           note: `Shop inventory: ${parseFloat(shopTotalQuantity.toFixed(2))}kg. Green stock: ${item.originalQuantity}kg. After ${haircutPercentage}% haircut: ${quantityAfterHaircut}kg available for ordering.`
         };
       } else if (item.source === 'shop_inventory') {
-        // For shop inventory coffees, check if they also have green stock available for ordering
-        const shopTotalQuantity = (item.shopSmallBags * 0.2) + (item.shopSmallBagsEspresso * 0.2) + (item.shopSmallBagsFilter * 0.2) + (item.shopLargeBags * 1.0);
+        const shopTotalQuantity = calculateShopInventoryKg(item);
         console.log(`[available-coffee] ${item.name}: Shop inventory - Small: ${item.shopSmallBags}×0.2kg, Small Espresso: ${item.shopSmallBagsEspresso}×0.2kg, Small Filter: ${item.shopSmallBagsFilter}×0.2kg, Large: ${item.shopLargeBags}×1.0kg = ${shopTotalQuantity.toFixed(2)}kg in shop inventory`);
         
-        // Check if this coffee also has green stock available for ordering
         const greenStockItem = greenStockCoffee.find(coffee => coffee.id === item.id);
         if (greenStockItem && greenStockItem.quantity > 0) {
-          // This coffee has both shop inventory AND green stock - show green stock for ordering
-          const haircutAmount = parseFloat((greenStockItem.quantity * (haircutPercentage / 100)).toFixed(2));
-          const quantityAfterHaircut = parseFloat((greenStockItem.quantity * (1 - haircutPercentage / 100)).toFixed(2));
+          const quantityAfterHaircut = calculateAvailableRetailKg(greenStockItem.quantity, haircutPercentage);
+          const haircutAmount = calculateHaircutAmount(quantityAfterHaircut, haircutPercentage);
           
           console.log(`[available-coffee] ${item.name}: Also has green stock ${greenStockItem.quantity}kg, available for ordering: ${quantityAfterHaircut}kg`);
           

--- a/src/pages/api/retail/create-order.js
+++ b/src/pages/api/retail/create-order.js
@@ -5,6 +5,12 @@ import { createActivityLog } from '@/lib/activity-service';
 import orderEmailService from '@/lib/order-email-service';
 import pushNotificationService from '@/lib/push-notification-service';
 import { getHaircutPercentage } from '@/lib/haircut-service';
+import {
+  calculateAvailableRetailKg,
+  calculateGreenConsumption,
+  calculateHaircutAmount,
+  calculateRetailKgFromBags,
+} from '@/lib/retail-quantity';
 
 export default async function handler(req, res) {
   // Create a dedicated prisma instance for this request
@@ -92,7 +98,13 @@ export default async function handler(req, res) {
         mediumBagsEspresso: mediumBagsEspresso,
         mediumBagsFilter: mediumBagsFilter,
         largeBags: largeBags,
-        totalQuantity: ((finalEspresso + finalFilter) * 0.2) + (mediumBagsEspresso * 0.5) + (mediumBagsFilter * 0.5) + (largeBags * 1.0)
+        totalQuantity: calculateRetailKgFromBags({
+          smallBagsEspresso: finalEspresso,
+          smallBagsFilter: finalFilter,
+          mediumBagsEspresso,
+          mediumBagsFilter,
+          largeBags,
+        }),
       };
     });
     
@@ -107,6 +119,33 @@ export default async function handler(req, res) {
         error: 'Invalid items in order', 
         details: invalidItems.map(item => item.coffeeId || 'unknown')
       });
+    }
+
+    const haircutPercentage = await getHaircutPercentage(prisma);
+
+    // Validate green stock before creating the order
+    for (const item of processedItems) {
+      const coffee = await prisma.greenCoffee.findUnique({
+        where: { id: item.coffeeId },
+        select: { id: true, name: true, quantity: true },
+      });
+
+      if (!coffee) {
+        await prisma.$disconnect();
+        return res.status(400).json({
+          error: `Coffee not found (ID: ${item.coffeeId})`,
+        });
+      }
+
+      const requiredGreen = calculateGreenConsumption(item.totalQuantity, haircutPercentage);
+      const availableRetail = calculateAvailableRetailKg(coffee.quantity, haircutPercentage);
+
+      if (coffee.quantity < requiredGreen) {
+        await prisma.$disconnect();
+        return res.status(400).json({
+          error: `Insufficient quantity for coffee ${coffee.name} (ID: ${item.coffeeId}). Available: ${availableRetail.toFixed(2)}kg, Requested: ${item.totalQuantity.toFixed(2)}kg`,
+        });
+      }
     }
 
     // Create order without transaction first
@@ -155,6 +194,8 @@ export default async function handler(req, res) {
             smallBags: item.smallBags,
             smallBagsEspresso: item.smallBagsEspresso,
             smallBagsFilter: item.smallBagsFilter,
+            mediumBagsEspresso: item.mediumBagsEspresso,
+            mediumBagsFilter: item.mediumBagsFilter,
             largeBags: item.largeBags,
             totalQuantity: item.totalQuantity
           }
@@ -167,25 +208,8 @@ export default async function handler(req, res) {
       // Update coffee quantities in parallel with haircut applied
       const coffeeUpdatePromises = processedItems.map(async (item) => {
         try {
-          // Get haircut percentage for this coffee
-          let haircutPercentage = 15; // Default fallback
-          try {
-            haircutPercentage = await getHaircutPercentage(prisma);
-            console.log(`[create-order] Coffee ${item.coffeeId}: Using haircut percentage: ${haircutPercentage}%`);
-          } catch (haircutError) {
-            console.error(`Error getting haircut percentage for coffee ${item.coffeeId}:`, haircutError);
-            // Already set to default 15%
-          }
-          
-          // Ensure haircut percentage is a valid number
-          if (isNaN(haircutPercentage) || haircutPercentage < 0 || haircutPercentage > 100) {
-            console.warn(`Invalid haircut percentage for coffee ${item.coffeeId}: ${haircutPercentage}, using default 15%`);
-            haircutPercentage = 15;
-          }
-          
-          const haircutMultiplier = 1 + (haircutPercentage / 100);
-          const totalGreenConsumption = item.totalQuantity * haircutMultiplier;
-          const haircutAmount = item.totalQuantity * (haircutPercentage / 100);
+          const totalGreenConsumption = calculateGreenConsumption(item.totalQuantity, haircutPercentage);
+          const haircutAmount = calculateHaircutAmount(item.totalQuantity, haircutPercentage);
           
           console.log(`[create-order] Coffee ${item.coffeeId} calculation:`);
           console.log(`  - Retail quantity ordered: ${item.totalQuantity}kg`);

--- a/src/pages/api/retail/pending-orders-by-coffee.js
+++ b/src/pages/api/retail/pending-orders-by-coffee.js
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import { getServerSession } from '@/lib/session';
+import { calculateRetailKgFromBags } from '@/lib/retail-quantity';
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') {
@@ -43,6 +44,7 @@ export default async function handler(req, res) {
 
     // Constants for bag sizes in kg (matching frontend)
     const SMALL_BAG_SIZE = 0.2; // 200g
+    const MEDIUM_BAG_SIZE = 0.5; // 500g
     const LARGE_BAG_SIZE = 1.0; // 1kg
     
     // Group by coffee and sum small bags (espresso and filter separately)
@@ -60,6 +62,8 @@ export default async function handler(req, res) {
         const smallBags = item.smallBags || 0;
         const espressoBags = item.smallBagsEspresso || 0;
         const filterBags = item.smallBagsFilter || 0;
+        const mediumEspressoBags = item.mediumBagsEspresso || 0;
+        const mediumFilterBags = item.mediumBagsFilter || 0;
         const largeBags = item.largeBags || 0;
         
         // For backward compatibility: if no espresso/filter data, treat smallBags as espresso
@@ -82,6 +86,8 @@ export default async function handler(req, res) {
             smallBags: 0,
             smallBagsEspresso: 0,
             smallBagsFilter: 0,
+            mediumBagsEspresso: 0,
+            mediumBagsFilter: 0,
             largeBags: 0,
             totalKg: 0,
             espressoKg: 0,
@@ -91,17 +97,23 @@ export default async function handler(req, res) {
           };
         }
         
-        // Add to the aggregated data (matching frontend logic exactly)
         coffeePendingTotals[coffeeId].smallBags += totalSmallBags;
         coffeePendingTotals[coffeeId].smallBagsEspresso += actualEspressoBags;
         coffeePendingTotals[coffeeId].smallBagsFilter += actualFilterBags;
+        coffeePendingTotals[coffeeId].mediumBagsEspresso += mediumEspressoBags;
+        coffeePendingTotals[coffeeId].mediumBagsFilter += mediumFilterBags;
         coffeePendingTotals[coffeeId].largeBags += largeBags;
         
-        // Calculate total in kg (using correct sizes)
-        const totalKg = (totalSmallBags * SMALL_BAG_SIZE) + (largeBags * LARGE_BAG_SIZE);
+        const totalKg = calculateRetailKgFromBags({
+          smallBagsEspresso: actualEspressoBags,
+          smallBagsFilter: actualFilterBags,
+          mediumBagsEspresso: mediumEspressoBags,
+          mediumBagsFilter: mediumFilterBags,
+          largeBags,
+        });
         const espressoKg = actualEspressoBags * SMALL_BAG_SIZE;
         const filterKg = actualFilterBags * SMALL_BAG_SIZE;
-        const mediumKg = 0;
+        const mediumKg = (mediumEspressoBags + mediumFilterBags) * MEDIUM_BAG_SIZE;
         
         coffeePendingTotals[coffeeId].totalKg += totalKg;
         coffeePendingTotals[coffeeId].espressoKg += espressoKg;

--- a/src/pages/api/retail/update-order-status.js
+++ b/src/pages/api/retail/update-order-status.js
@@ -4,6 +4,7 @@ import { verifyRequestAndGetUser } from '@/lib/auth';
 import orderEmailService from '@/lib/order-email-service';
 import pushNotificationService from '@/lib/push-notification-service';
 import { getHaircutPercentage } from '@/lib/haircut-service';
+import { calculateGreenConsumption, calculateHaircutAmount, countTotalBags } from '@/lib/retail-quantity';
 
 /**
  * Handle green coffee stock adjustments when orders are cancelled
@@ -24,16 +25,14 @@ async function handleGreenCoffeeStockAdjustments(tx, order, newStatus) {
   try {
     // Get current haircut percentage
     const haircutPercentage = await getHaircutPercentage(tx);
-    const haircutMultiplier = 1 + (haircutPercentage / 100);
     
-    console.log(`[green-coffee-stock] Using haircut percentage: ${haircutPercentage}% (multiplier: ${haircutMultiplier})`);
+    console.log(`[green-coffee-stock] Using haircut percentage: ${haircutPercentage}%`);
     
     // Process each item in the cancelled order
     const stockAdjustmentPromises = order.items.map(async (item) => {
       try {
-        // Calculate the total green coffee consumption that was originally deducted
-        const totalGreenConsumption = (item.totalQuantity || 0) * haircutMultiplier;
-        const haircutAmount = (item.totalQuantity || 0) * (haircutPercentage / 100);
+        const totalGreenConsumption = calculateGreenConsumption(item.totalQuantity || 0, haircutPercentage);
+        const haircutAmount = calculateHaircutAmount(item.totalQuantity || 0, haircutPercentage);
         
         console.log(`[green-coffee-stock] Restoring coffee ${item.coffeeId}:`);
         console.log(`  - Retail quantity: ${item.totalQuantity || 0}kg`);
@@ -109,9 +108,7 @@ async function handleLabelQuantityUpdates(tx, order, newStatus) {
   const coffeeLabelsNeeded = {};
   
   for (const item of order.items) {
-    // Calculate total bags for this coffee type (1 label per bag)
-    const totalBags = (item.smallBags || 0) + (item.smallBagsEspresso || 0) + 
-                     (item.smallBagsFilter || 0) + (item.largeBags || 0);
+    const totalBags = countTotalBags(item);
     
     if (totalBags > 0) {
       coffeeLabelsNeeded[item.coffeeId] = (coffeeLabelsNeeded[item.coffeeId] || 0) + totalBags;

--- a/src/pages/orders.js
+++ b/src/pages/orders.js
@@ -49,6 +49,7 @@ import IconlessAlert from '../components/ui/IconlessAlert';
 import CollapsibleAlert from '../components/ui/CollapsibleAlert';
 import ShopStockSummary from '../components/retail/ShopStockSummary';
 import PendingOrdersSummary from '../components/retail/PendingOrdersSummary';
+import { calculateRetailKgFromBags } from '@/lib/retail-quantity';
 
 // Simple Order Dialog Component
 function OrderDialog({ open, onClose, coffeeItems, selectedShop, haircutPercentage }) {
@@ -128,7 +129,13 @@ function OrderDialog({ open, onClose, coffeeItems, selectedShop, haircutPercenta
   
   // Calculate total quantity for a coffee item in kg
   const calculateTotalQuantity = (smallBagsEspresso, smallBagsFilter, mediumBagsEspresso, mediumBagsFilter, largeBags) => {
-    return ((smallBagsEspresso + smallBagsFilter) * 0.2) + ((mediumBagsEspresso + mediumBagsFilter) * 0.5) + (largeBags * 1.0);
+    return calculateRetailKgFromBags({
+      smallBagsEspresso,
+      smallBagsFilter,
+      mediumBagsEspresso,
+      mediumBagsFilter,
+      largeBags,
+    });
   };
   
   // Validate if the requested quantity is within available limits
@@ -137,13 +144,13 @@ function OrderDialog({ open, onClose, coffeeItems, selectedShop, haircutPercenta
     if (!coffee) return true; // Can't validate if coffee not found
     
     const requestedQuantity = calculateTotalQuantity(smallBagsEspresso, smallBagsFilter, mediumBagsEspresso, mediumBagsFilter, largeBags);
-    const realTimeAvailable = calculateRealTimeAvailableQuantity(coffee);
-    const isValid = realTimeAvailable >= requestedQuantity;
+    const remainingQuantity = calculateRealTimeAvailableQuantity(coffee);
+    const isValid = remainingQuantity >= 0;
     
     // Update validation errors
     setValidationErrors(prev => ({
       ...prev,
-      [coffeeId]: isValid ? null : `Exceeds available quantity (${realTimeAvailable.toFixed(2)}kg)`
+      [coffeeId]: isValid ? null : `Exceeds available quantity (${coffee.quantity.toFixed(2)}kg)`
     }));
     
     return isValid;
@@ -372,6 +379,8 @@ function OrderDialog({ open, onClose, coffeeItems, selectedShop, haircutPercenta
             newOrderItems[coffee.id] = { 
               smallBagsEspresso: '', 
               smallBagsFilter: '', 
+              mediumBagsEspresso: '',
+              mediumBagsFilter: '',
               largeBags: '' 
             };
           }
@@ -384,6 +393,8 @@ function OrderDialog({ open, onClose, coffeeItems, selectedShop, haircutPercenta
           newOrderItems[templateItem.coffeeId] = {
             smallBagsEspresso: templateItem.smallBagsEspresso.toString(),
             smallBagsFilter: templateItem.smallBagsFilter.toString(),
+            mediumBagsEspresso: (templateItem.mediumBagsEspresso || 0).toString(),
+            mediumBagsFilter: (templateItem.mediumBagsFilter || 0).toString(),
             largeBags: templateItem.largeBags.toString()
           };
         }
@@ -423,19 +434,29 @@ function OrderDialog({ open, onClose, coffeeItems, selectedShop, haircutPercenta
     try {
       const templateItems = Object.entries(orderItems)
         .filter(([coffeeId, quantities]) => {
-          const total = (parseInt(quantities.smallBagsEspresso) || 0) +
-                        (parseInt(quantities.smallBagsFilter) || 0) +
-                        (parseInt(quantities.largeBags) || 0);
+          const total = calculateRetailKgFromBags({
+            smallBagsEspresso: quantities.smallBagsEspresso,
+            smallBagsFilter: quantities.smallBagsFilter,
+            mediumBagsEspresso: quantities.mediumBagsEspresso,
+            mediumBagsFilter: quantities.mediumBagsFilter,
+            largeBags: quantities.largeBags,
+          });
           return total > 0;
         })
         .map(([coffeeId, quantities]) => ({
           coffeeId,
           smallBagsEspresso: parseInt(quantities.smallBagsEspresso) || 0,
           smallBagsFilter: parseInt(quantities.smallBagsFilter) || 0,
+          mediumBagsEspresso: parseInt(quantities.mediumBagsEspresso) || 0,
+          mediumBagsFilter: parseInt(quantities.mediumBagsFilter) || 0,
           largeBags: parseInt(quantities.largeBags) || 0,
-          totalQuantity: ((parseInt(quantities.smallBagsEspresso) || 0) +
-                          (parseInt(quantities.smallBagsFilter) || 0)) * 0.2 +
-                          (parseInt(quantities.largeBags) || 0) * 1.0
+          totalQuantity: calculateRetailKgFromBags({
+            smallBagsEspresso: quantities.smallBagsEspresso,
+            smallBagsFilter: quantities.smallBagsFilter,
+            mediumBagsEspresso: quantities.mediumBagsEspresso,
+            mediumBagsFilter: quantities.mediumBagsFilter,
+            largeBags: quantities.largeBags,
+          }),
         }));
 
       if (templateItems.length === 0) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigation found two root causes behind retail coffees not matching green bean stock and incorrect quantity behavior on the order screen.

### Issues found

1. **Haircut formula mismatch** — The order screen showed available stock as `green × (1 - haircut%)`, but order creation deducted `retail × (1 + haircut%)`. Ordering the full displayed amount consumed too much green stock and left a phantom remainder.
2. **Order validation bug** — The dialog subtracted entered quantities from available, then compared the *remaining* amount against the *requested* amount. Valid orders at the limit were rejected (e.g. ordering all 85 kg when 85 kg was shown as available).
3. **Medium bags dropped on create** — 500g bag quantities were included in kg totals and green deduction but not saved on `RetailOrderItem`.
4. **Pending order totals ignored medium bags** — Pending summary under-reported committed stock.
5. **No server-side stock check** — Orders could drive green stock negative.

### Fixes

- Added `src/lib/retail-quantity.js` with shared bag-to-kg and haircut helpers
- Aligned haircut math across display, create-order, and cancel-restore paths
- Fixed order dialog validation to check `remaining >= 0`
- Persist `mediumBagsEspresso` / `mediumBagsFilter` on order create
- Added server-side green stock validation before order creation
- Fixed label counting and shop inventory filter bugs

### How green coffee logic works

| Layer | Storage | Meaning |
|-------|---------|---------|
| Green stock | `GreenCoffee.quantity` (kg) | Raw bean inventory |
| Orderable retail | `green × (1 - haircut%)` | What shops can order after roasting loss |
| Green consumed per order | `retail / (1 - haircut%)` | Actual green deducted on order create |
| Shop stock | `RetailInventory` bag counts | Updated when order is `DELIVERED` |

## Test plan

- [ ] Green coffee page shows 100 kg → order dialog shows 85 kg available (15% haircut)
- [ ] Ordering exactly 85 kg retail succeeds and reduces green stock to ~0 kg
- [ ] Entering bag quantities that total available kg no longer shows false validation errors
- [ ] 500g bag orders save correctly and appear in pending totals
- [ ] Cancelling an order restores the correct green stock amount

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2ebb899-8d80-4a4f-9abe-21792534ff99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2ebb899-8d80-4a4f-9abe-21792534ff99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

